### PR TITLE
Blackduck: Automated PR: Update org.jruby:jruby:9.4.3.0 to 9.4.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
       <dependency>
         <groupId>org.jruby</groupId>
         <artifactId>jruby</artifactId>
-        <version>9.4.3.0</version>
+        <version>9.4.13.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Vulnerabilities associated with org.jruby:jruby:9.4.3.0
[BDSA-2025-3923](https://openhub.net/vulnerabilities/bdsa/BDSA-2025-3923) *(HIGH)*: jruby-openssl is vulnerable to adversary-in-the-middle attacks due to missing verification of certificate hostnames. This could allow an attacker to perform adversary-in-the-middle attacks by supplying valid certificates for any domain.

[Click Here To See More Details On Server](https://sflab.blackduck.service.softflow.zone/api/projects/4ef0c1a3-b712-40b9-8cda-e2c0431cdd69/versions/af8308f2-663e-4d16-af53-c39124e01424/vulnerability-bom?selectedItem=da0b8566-9745-4ba4-b3f4-5dfdb1f1e824)